### PR TITLE
Allow resources params from data and json arguments

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -68,11 +68,11 @@ if (typeof actions[action] !== 'function') {
   process.exit(1);
 }
 
-// get resource
-deps.resource = resourceParser(argv, aliases);
-
 // get data
 deps.data = dataParser(argv);
+
+// get resource
+deps.resource = resourceParser(argv, aliases, deps.data);
 
 // get options
 deps.options = optionsParser(argv);

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -134,7 +134,7 @@ function resolveProjectId()
 
 function checkResourceId(cb)
 {
-  var check = (data[resource.type.substr(0, resource.type.length - 1) + '_id']) ? true : false;
+  var check = (data[resource.type.substr(0, resource.type.length - 1) + '_id']) || resource.id.length > 0 ? true : false;
 
   if (!check) {
     cb('missing resource id', null);

--- a/lib/parser/resourceParser.js
+++ b/lib/parser/resourceParser.js
@@ -1,7 +1,7 @@
 var defaults = require('../defaults');
 var split = require('../utils').split;
 
-function parse(argv, aliases)
+function parse(argv, aliases, data)
 {
   var resource = defaults.resource();
   var _resource = argv._[1] || '';
@@ -29,14 +29,14 @@ function parse(argv, aliases)
   }
 
 // normalize resource
-  resource.namespace = (_resource.length >= 2) ? _resource[0] : null;
-  resource.project = (_resource.length >= 3) ? _resource[1] : null;
-  resource.type = (_resource.length >= 3) ?
+  resource.namespace = data.namespace ? data.namespace : (_resource.length >= 2) ? _resource[0] : null;
+  resource.project = data.project ? data.project : (_resource.length >= 3) ? _resource[1] : null;
+  resource.type = data.type ? data.type : (_resource.length >= 3) ?
       _resource[2] : (_resource.length === 1) ? _resource[0] : _resource[1]
   ;
-  resource.id = _resource[3] || null;
+  resource.id = data.id ? data.id : _resource[3] || null;
 
-  if (resource.type.substr(-1,1) !== 's') {
+  if (resource.type.length > 0 && resource.type.substr(-1,1) !== 's') {
     resource.type += 's';
   }
 


### PR DESCRIPTION
- re-order parsing of data and resource arguments
- pass data to the resource parser and prefer this argument (in order)
to first get resource arguments from data or json args
- loosen validation to allow arguments here in lieu of as argv[1]